### PR TITLE
Fixes test on master

### DIFF
--- a/test/fixtures/graphql-tag/converts inline gql tag to a compiled version/expected.js
+++ b/test/fixtures/graphql-tag/converts inline gql tag to a compiled version/expected.js
@@ -29,7 +29,11 @@ const foo = {
     'end': 15,
     'source': {
       'body': 'query foo {foo}',
-      'name': 'GraphQL request'
+      'name': 'GraphQL request',
+      'locationOffset': {
+        'line': 1,
+        'column': 1
+      }
     }
   }
 };


### PR DESCRIPTION
This fixes #1 -- I'm guessing this diff came up because of one of the babel sub-dependencies that got updated? Checking in a `package-lock.json` might help here? I didn't include it in this PR, but let me know if you'd like that and I can add it.