### PR TITLE
Remove peerDependency on graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "main": "dist/index.js",
   "name": "babel-plugin-graphql-tag",
   "peerDependencies": {
-    "graphql": "^0.10.1",
     "graphql-tag": "^2.2.0"
   },
   "repository": {


### PR DESCRIPTION
It seems that graphql is not a direct dependency of babel-plugin-graphql-tag, so it should be safe to remove the peerDependency on graphql (and rely on graphql-tag to set its own peerDependency on graphql).

I have not tested this change.

Solves https://github.com/gajus/babel-plugin-graphql-tag/issues/8