### PR TITLE
Clone 'uniqueFn' before using it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import {
+  cloneDeep,
   isIdentifier,
   isMemberExpression,
   isImportDefaultSpecifier,
@@ -152,7 +153,7 @@ export default () => {
             'body',
             variableDeclaration(
               'const',
-              [variableDeclarator(uniqueId, uniqueFn)]
+              [variableDeclarator(uniqueId, cloneDeep(uniqueFn))]
             )
           );
         }


### PR DESCRIPTION
When running `babel-plugin-graphql-tag` on our codebase, I was getting a strange error saying that `variableDeclarator` expected an `ExpressionStatement`, but was getting a `FunctionDeclaration`. After a bunch of investigation, it turns out that the Babel "arrow functions" transform mutates `ArrowFunctionExpression` nodes to convert them to `FunctionDeclaration` nodes, and thus the `uniqueFn` variable was being mutated, causing this error.

This PR resolves this by cloning the expression before using it in the variable declarator.

I profiled this a bit, and this `cloneDeep` only adds about half a millisecond to the transform step.