### PR TITLE
Update README to include installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,13 @@ const foo = gql`
 
 ```
 
+## Installation
+
+Ensure that the package exists in babel configuration:
+
+```json
+{
+  "plugins": ["babel-plugin-graphql-tag"]
+}
+
+```


### PR DESCRIPTION
Add installations notes to README.

I know this is may seem fundamental knowledge, but some people (like past me) were not aware that GraphQL was **not** being parsed into AST and assumed that this just "automagically" worked. Silly me. This may help some others.