### PR TITLE
Adding ability to use packages other than graphql-tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ const foo = gql`
 
 ```
 
+### Options
+
+- `importName` - The name of the module import to process (default = "graphql-tag")
+- `onlyMatchImportSuffix` - Matches the end of the import instead of the entire name. Useful for relative imports, e.g. `./utils/graphql` (default = false)

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,12 @@ const uniqueFn = parseExpression(`
   }
 `);
 
-export default declare((api) => {
+export default declare((api, options) => {
   api.assertVersion(7);
+  const {
+    importName = 'graphql-tag',
+    onlyMatchImportSuffix = false
+  } = options;
 
   const compile = (path: Object, uniqueId) => {
     const source = path.node.quasis.reduce((head, quasi) => {
@@ -109,7 +113,8 @@ export default declare((api) => {
 
         programPath.traverse({
           ImportDeclaration (path: Object) {
-            if (path.node.source.value === 'graphql-tag') {
+            const pathValue = path.node.source.value;
+            if (onlyMatchImportSuffix ? pathValue.endsWith(importName) : pathValue === importName) {
               const defaultSpecifier = path.node.specifiers.find((specifier) => {
                 return isImportDefaultSpecifier(specifier);
               });

--- a/test/fixtures/graphql-tag/handles different imports based on options/input.js
+++ b/test/fixtures/graphql-tag/handles different imports based on options/input.js
@@ -1,0 +1,3 @@
+import gql from "../../../node_modules/graphql-tag";
+
+const foo = gql`query foo {foo}`;

--- a/test/fixtures/graphql-tag/handles different imports based on options/options.json
+++ b/test/fixtures/graphql-tag/handles different imports based on options/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "onlyMatchImportSuffix": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/graphql-tag/handles different imports based on options/output.mjs
+++ b/test/fixtures/graphql-tag/handles different imports based on options/output.mjs
@@ -1,0 +1,37 @@
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 15,
+    "source": {
+      "body": "query foo {foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};


### PR DESCRIPTION
Adding the ability to use gql parsers other than `graphql-tag` by adding two options: `importName` and `onlyMatchImportSuffix`.  The latter is necessary for relative imports and allows things like 

```js
import gql from '../utils/gql';
```