### PR TITLE
add @babel/helper-plugin-utils to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/parser": "^7.3.2",
     "babel-literal-to-ast": "^2.1.0",
     "debug": "^4.1.1"


### PR DESCRIPTION
I published this modification here https://www.npmjs.com/package/@pablosz/babel-plugin-graphql-tag if needed before this PR is merged. 
Just change babel-plugin-graphql-tag to @pablosz/babel-plugin-graphql-tag. 

Fixes #36 
Fixes #32 