### PR TITLE
@babel/helper-plugin-utils is listed twice in pacakge.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
-    "@babel/helper-plugin-utils": "^7.0.0",
     "@babel/helper-transform-fixture-test-runner": "^7.1.2",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-flow": "^7.0.0",


### PR DESCRIPTION
remove @babel/helper-plugin-utils from devDependencies as it's also in dependencies

it was added to dependencies in this pr https://github.com/gajus/babel-plugin-graphql-tag/pull/37 but not removed from devDependencies