### PR TITLE
Fix node reuse on TaggedTemplateExpression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -144,7 +144,7 @@ export default declare((api, options) => {
 
                 uniqueUsed = uniqueUsed || used;
 
-                path.replaceWith(body);
+                path.replaceWith(cloneDeep(body));
               } catch (error) {
                 // eslint-disable-next-line no-console
                 console.error('error', error);


### PR DESCRIPTION
Use cloneDeep in order to prevent node reuse.
This should fix tests.