### PR TITLE
Add apollo v3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,24 @@ Removing the `graphql-tag` dependecy from the bundle saves approx. 50 KB.
 * Searches for imports of `graphql-tag` and removes them.
 * Searches for [tagged template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals) with `gql` identifier and compiles them using `graphql-tag`.
 
+## Apollo v3 Disclaimer
+
+Apollo v3 asks users to import gql from `@apollo/client`, if you are using apollo client v3 you can provid plugin option `importName: '@apollo/client'`
+
+```
+plugins: [
+  ['babel-plugin-graphql-tag', { importName: '@apollo/client' }]
+]
+```
+
 ## Example compilation
 
 Input:
 
 ```js
 import gql from 'graphql-tag';
+// if using apollo v3
+import { gql } from '@apollo/client';
 
 const foo = gql`query {bar}`;
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Compiles GraphQL tagged template strings using graphql-tag",
   "devDependencies": {
+    "@apollo/client": "^3.1.0",
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/helper-transform-fixture-test-runner": "^7.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const {
   cloneDeep,
   isIdentifier,
   isMemberExpression,
+  isImportSpecifier,
   isImportDefaultSpecifier,
   variableDeclaration,
   variableDeclarator,
@@ -122,6 +123,10 @@ export default declare((api, options) => {
             const pathValue = path.node.source.value;
             if (onlyMatchImportSuffix ? pathValue.endsWith(importName) : pathValue === importName) {
               const defaultSpecifier = path.node.specifiers.find((specifier) => {
+                if (isImportSpecifier(specifier)) {
+                  return specifier.local.name === 'gql';
+                }
+
                 return isImportDefaultSpecifier(specifier);
               });
 

--- a/test/fixtures/apollov3/converts inline gql tag to a compiled version/input.js
+++ b/test/fixtures/apollov3/converts inline gql tag to a compiled version/input.js
@@ -1,0 +1,3 @@
+import { gql } from '@apollo/client';
+
+const foo = gql`query foo {foo}`;

--- a/test/fixtures/apollov3/converts inline gql tag to a compiled version/options.json
+++ b/test/fixtures/apollov3/converts inline gql tag to a compiled version/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/converts inline gql tag to a compiled version/output.mjs
+++ b/test/fixtures/apollov3/converts inline gql tag to a compiled version/output.mjs
@@ -1,0 +1,37 @@
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 15,
+    "source": {
+      "body": "query foo {foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};

--- a/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/input.js
+++ b/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/input.js
@@ -1,0 +1,31 @@
+import { gql } from '@apollo/client';
+
+const bar = gql`
+  fragment barFragment on Foo {
+    field1
+    field2
+  }
+`;
+
+const baz = {
+  fragments: {
+    foo: gql`
+      fragment bazFragment on Foo {
+        field2
+        field3
+      }
+    `
+  }
+};
+
+const foo = gql`
+  query foo {
+    foo {
+      ...barFragment
+      ...bazFragment
+    }
+  }
+
+  ${bar}
+  ${baz.fragments.foo}
+`;

--- a/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/options.json
+++ b/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/output.mjs
+++ b/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/output.mjs
@@ -1,0 +1,177 @@
+const _unique = definitions => {
+  const names = {};
+  return definitions.filter(definition => {
+    if (definition.kind !== 'FragmentDefinition') {
+      return true;
+    }
+
+    const name = definition.name.value;
+
+    if (names[name]) {
+      return false;
+    } else {
+      names[name] = true;
+      return true;
+    }
+  });
+};
+
+const bar = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "FragmentDefinition",
+    "name": {
+      "kind": "Name",
+      "value": "barFragment"
+    },
+    "typeCondition": {
+      "kind": "NamedType",
+      "name": {
+        "kind": "Name",
+        "value": "Foo"
+      }
+    },
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "field1"
+        },
+        "arguments": [],
+        "directives": []
+      }, {
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "field2"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 59,
+    "source": {
+      "body": "\n  fragment barFragment on Foo {\n    field1\n    field2\n  }\n",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};
+const baz = {
+  fragments: {
+    foo: {
+      "kind": "Document",
+      "definitions": [{
+        "kind": "FragmentDefinition",
+        "name": {
+          "kind": "Name",
+          "value": "bazFragment"
+        },
+        "typeCondition": {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Foo"
+          }
+        },
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [{
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "field2"
+            },
+            "arguments": [],
+            "directives": []
+          }, {
+            "kind": "Field",
+            "name": {
+              "kind": "Name",
+              "value": "field3"
+            },
+            "arguments": [],
+            "directives": []
+          }]
+        }
+      }],
+      "loc": {
+        "start": 0,
+        "end": 79,
+        "source": {
+          "body": "\n      fragment bazFragment on Foo {\n        field2\n        field3\n      }\n    ",
+          "name": "GraphQL request",
+          "locationOffset": {
+            "line": 1,
+            "column": 1
+          }
+        }
+      }
+    }
+  }
+};
+const foo = {
+  "kind": "Document",
+  "definitions": _unique([{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": [],
+        "selectionSet": {
+          "kind": "SelectionSet",
+          "selections": [{
+            "kind": "FragmentSpread",
+            "name": {
+              "kind": "Name",
+              "value": "barFragment"
+            },
+            "directives": []
+          }, {
+            "kind": "FragmentSpread",
+            "name": {
+              "kind": "Name",
+              "value": "bazFragment"
+            },
+            "directives": []
+          }]
+        }
+      }]
+    }
+  }].concat(bar.definitions, baz.fragments.foo.definitions)),
+  "loc": {
+    "start": 0,
+    "end": 84,
+    "source": {
+      "body": "\n  query foo {\n    foo {\n      ...barFragment\n      ...bazFragment\n    }\n  }\n\n  \n  \n",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};

--- a/test/fixtures/apollov3/does not transpile template literals without a tag/input.js
+++ b/test/fixtures/apollov3/does not transpile template literals without a tag/input.js
@@ -1,0 +1,3 @@
+import { gql } from '@apollo/client';
+
+const foo = `query foo {foo}`;

--- a/test/fixtures/apollov3/does not transpile template literals without a tag/options.json
+++ b/test/fixtures/apollov3/does not transpile template literals without a tag/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/does not transpile template literals without a tag/output.mjs
+++ b/test/fixtures/apollov3/does not transpile template literals without a tag/output.mjs
@@ -1,0 +1,1 @@
+const foo = `query foo {foo}`;

--- a/test/fixtures/apollov3/does not transpile template literals without gql tag/input.js
+++ b/test/fixtures/apollov3/does not transpile template literals without gql tag/input.js
@@ -1,0 +1,3 @@
+import { gql } from '@apollo/client';
+
+const foo = bar`query foo {foo}`;

--- a/test/fixtures/apollov3/does not transpile template literals without gql tag/options.json
+++ b/test/fixtures/apollov3/does not transpile template literals without gql tag/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/does not transpile template literals without gql tag/output.mjs
+++ b/test/fixtures/apollov3/does not transpile template literals without gql tag/output.mjs
@@ -1,0 +1,1 @@
+const foo = bar`query foo {foo}`;

--- a/test/fixtures/apollov3/handles different imports based on options/input.js
+++ b/test/fixtures/apollov3/handles different imports based on options/input.js
@@ -1,0 +1,3 @@
+import { gql } from "../../../node_modules/@apollo/client";
+
+const foo = gql`query foo {foo}`;

--- a/test/fixtures/apollov3/handles different imports based on options/options.json
+++ b/test/fixtures/apollov3/handles different imports based on options/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client",
+        "onlyMatchImportSuffix": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/handles different imports based on options/output.mjs
+++ b/test/fixtures/apollov3/handles different imports based on options/output.mjs
@@ -1,0 +1,37 @@
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 15,
+    "source": {
+      "body": "query foo {foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};

--- a/test/fixtures/apollov3/preserves imports when cannot parse query/input.js
+++ b/test/fixtures/apollov3/preserves imports when cannot parse query/input.js
@@ -1,0 +1,2 @@
+import { gql } from '@apollo/client';
+const bar = gql`query foo {`;

--- a/test/fixtures/apollov3/preserves imports when cannot parse query/options.json
+++ b/test/fixtures/apollov3/preserves imports when cannot parse query/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/preserves imports when cannot parse query/output.mjs
+++ b/test/fixtures/apollov3/preserves imports when cannot parse query/output.mjs
@@ -1,0 +1,2 @@
+import { gql } from '@apollo/client';
+const bar = gql`query foo {`;

--- a/test/fixtures/apollov3/preserves other imports from graphql-tag package/input.js
+++ b/test/fixtures/apollov3/preserves other imports from graphql-tag package/input.js
@@ -1,0 +1,3 @@
+import { gql, other } from '@apollo/client';
+
+const foo = gql`query foo {foo}`;

--- a/test/fixtures/apollov3/preserves other imports from graphql-tag package/options.json
+++ b/test/fixtures/apollov3/preserves other imports from graphql-tag package/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/preserves other imports from graphql-tag package/output.mjs
+++ b/test/fixtures/apollov3/preserves other imports from graphql-tag package/output.mjs
@@ -1,0 +1,38 @@
+import { other } from '@apollo/client';
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 15,
+    "source": {
+      "body": "query foo {foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};

--- a/test/fixtures/apollov3/strips ignored characters from source/input.js
+++ b/test/fixtures/apollov3/strips ignored characters from source/input.js
@@ -1,0 +1,3 @@
+import { gql } from '@apollo/client';
+
+const foo = gql`query foo {foo}`;

--- a/test/fixtures/apollov3/strips ignored characters from source/options.json
+++ b/test/fixtures/apollov3/strips ignored characters from source/options.json
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client",
+        "strip": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/strips ignored characters from source/output.mjs
+++ b/test/fixtures/apollov3/strips ignored characters from source/output.mjs
@@ -1,0 +1,37 @@
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 14,
+    "source": {
+      "body": "query foo{foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};

--- a/test/fixtures/apollov3/transpiles a single unnamed query/input.js
+++ b/test/fixtures/apollov3/transpiles a single unnamed query/input.js
@@ -1,0 +1,3 @@
+import { gql } from '@apollo/client';
+
+const foo = gql`{foo}`;

--- a/test/fixtures/apollov3/transpiles a single unnamed query/options.json
+++ b/test/fixtures/apollov3/transpiles a single unnamed query/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importName": "@apollo/client"
+      }
+    ]
+  ]
+}

--- a/test/fixtures/apollov3/transpiles a single unnamed query/output.mjs
+++ b/test/fixtures/apollov3/transpiles a single unnamed query/output.mjs
@@ -1,0 +1,33 @@
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 5,
+    "source": {
+      "body": "{foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};


### PR DESCRIPTION
Implementation:

Apollo v3 asks users to `import { gql } from @apollo/client` the problem here is because the library was checking for default import and discarding this kind of result even if `importName: '@apollo/client'` provided.

Fixtures is the same as fixtures/graphql-tag just renaming the import just like apollo team suggested.