### PR TITLE
Support transform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,28 @@ const foo = gql`
 - `importSources` - An array of names for modules to import (default = ["graphql-tag", "@apollo/client"])
 - `onlyMatchImportSuffix` - Matches the end of the import instead of the entire name. Useful for relative imports, e.g. `./utils/graphql` (default = false)
 - `strip` - Strips insignificant characters such as whitespace from the original GraphQL string literal to reduce the size of compiled AST (default = false)
+- `transform` - By default, grapqhl query strings will be replaced with their AST representations, but you can override that behavior and do whatever you like. One possible use case would be to implement persisted queries:
+
+```js
+// babel.config.js
+plugins: [
+    [
+        "babel-plugin-graphql-tag",
+        {
+            strip: true,
+            transform: (source, ast) => {
+                const h = hash(source); // use your favorite hashing method
+                graphqlAstHashes[h] = ast; // write this to a file when compilation is complete
+                return {
+                    queryId: h
+                };
+            }
+        }
+    ]
+]
+```
+
+
 
 ### Known Issues
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@babel/helper-transform-fixture-test-runner": "^7.1.2",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-flow": "^7.0.0",
+    "cross-env": "^7.0.2",
     "eslint": "^5.13.0",
     "eslint-config-canonical": "^21.0.2",
     "flow-bin": "^0.93.0",
@@ -40,9 +41,9 @@
     "jest": "^24.1.0"
   },
   "scripts": {
-    "build": "rm -fr ./dist && NODE_ENV=production babel ./src --out-dir ./dist --source-maps --copy-files",
+    "build": "rm -fr ./dist && cross-env NODE_ENV=production babel ./src --out-dir ./dist --source-maps --copy-files",
     "lint": "eslint ./src && flow",
-    "test": " NODE_ENV=test jest"
+    "test": "cross-env NODE_ENV=test jest"
   },
   "version": "3.0.0"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -68,8 +68,8 @@ export default declare((api, options) => {
     });
 
     debug('compiling a GraphQL query', source);
-
-    const queryDocument = gql(strip ? stripIgnoredCharacters(source) : source);
+    const finalSource = strip ? stripIgnoredCharacters(source) : source;
+    let queryDocument = gql(strip ? stripIgnoredCharacters(finalSource) : finalSource);
 
     // If a document contains only one operation, that operation may be unnamed:
     // https://facebook.github.io/graphql/#sec-Language.Query-Document
@@ -79,6 +79,10 @@ export default declare((api, options) => {
           throw new Error('GraphQL query must have name.');
         }
       }
+    }
+
+    if (options.transform && options.transform) {
+      queryDocument = options.transform(finalSource, queryDocument);
     }
 
     const body = parseLiteral(queryDocument);


### PR DESCRIPTION
I've been hunting around all week for a way to combine the concept of `graphql-tag` with persisted queries, and I haven't found anything I like. You're probably thinking that persisted queries belongs in a dedicated package, but to me it's really just a small configuration detail for a package like this one. If we allow the client to transform the queryDocument object before it's injected into the AST, then the rest is trivial:

```js

const graphqlAstHashes = {};

...

// babel.config.js
plugins: [
    [
        "babel-plugin-graphql-tag",
        {
            strip: true,
            transform: (source, ast) => {
                const h = hash(source); // use your favorite hashing method
                graphqlAstHashes[h] = ast; // write this to a file when compilation is complete
                return {
                    queryId: h
                };
            }
        }
    ]
]
```

I'm sort of new to babel concepts, so I fully expect you guys to have lots of feedback for me. 
