### PR TITLE
Add support for multiple custom gql tag identifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ script:
   - npm run lint
   - npm run build
   - npm run test
+after_success:
+  - NODE_ENV=production npm run build
+  - semantic-release
 notifications:
   email: false
 sudo: false

--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ const foo = gql`
 
 ### Options
 
-- `importSources` - An array of names for modules to import (default = ["graphql-tag", "@apollo/client"])
+- `importSources` - An array of names for modules to import (default = `["graphql-tag", "@apollo/client"]`)
 - `onlyMatchImportSuffix` - Matches the end of the import instead of the entire name. Useful for relative imports, e.g. `./utils/graphql` (default = false)
 - `strip` - Strips insignificant characters such as whitespace from the original GraphQL string literal to reduce the size of compiled AST (default = false)
 - `transform` - By default, grapqhl query strings will be replaced with their AST representations, but you can override that behavior and do whatever you like. One possible use case would be to implement persisted queries:
+- `gqlTagIdentifiers` - An array of names for gql tag identifiers (default = `["gql"]`)
 
 ```js
 // babel.config.js
@@ -134,8 +135,6 @@ plugins: [
     ]
 ]
 ```
-
-
 
 ### Known Issues
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "graphql": "^14.3.0",
     "graphql-tag": "^2.10.1",
     "husky": "^1.3.1",
-    "jest": "^24.1.0"
+    "jest": "^24.1.0",
+    "semantic-release": "^17.1.2"
   },
   "husky": {
     "hooks": {

--- a/src/index.js
+++ b/src/index.js
@@ -47,9 +47,12 @@ export default declare((api, options) => {
   api.assertVersion(7);
   const {
     importSources = ['graphql-tag', '@apollo/client'],
+    gqlTagIdentifiers = ['gql'],
     onlyMatchImportSuffix = false,
     strip = false,
   } = options;
+
+  const gqlTagIdentifiersSet = new Set(gqlTagIdentifiers);
 
   const compile = (path: Object, uniqueId) => {
     // eslint-disable-next-line unicorn/no-reduce
@@ -139,7 +142,7 @@ export default declare((api, options) => {
 
                     if (isObjectPattern(gqlDeclaration.id)) {
                       const gqlProperty = gqlDeclaration.id.properties.find((property) => {
-                        return property.key.name === 'gql';
+                        return gqlTagIdentifiersSet.has(property.key.name);
                       });
                       tagNames.push(gqlProperty.key.name);
 
@@ -151,7 +154,7 @@ export default declare((api, options) => {
                       }
 
                       gqlDeclaration.id.properties = gqlDeclaration.id.properties.filter((property) => {
-                        return property.key.name !== 'gql';
+                        return !gqlTagIdentifiersSet.has(property.key.name);
                       });
 
                       return;
@@ -171,7 +174,7 @@ export default declare((api, options) => {
             const pathValue = path.node.source.value;
             const gqlSpecifier = path.node.specifiers.find((specifier) => {
               if (isImportSpecifier(specifier)) {
-                return specifier.local.name === 'gql';
+                return gqlTagIdentifiersSet.has(specifier.local.name);
               }
 
               if (isImportDefaultSpecifier(specifier)) {

--- a/test/fixtures/graphql-tag/allows a custom tag identifier/input.js
+++ b/test/fixtures/graphql-tag/allows a custom tag identifier/input.js
@@ -1,0 +1,3 @@
+import { gqlTagPrimaryGateway } from 'primary-gateway-graphql-tag';
+
+const foo = gqlTagPrimaryGateway`query foo {foo}`;

--- a/test/fixtures/graphql-tag/allows a custom tag identifier/options.json
+++ b/test/fixtures/graphql-tag/allows a custom tag identifier/options.json
@@ -1,0 +1,12 @@
+{
+  "plugins": [
+    [
+      "../../../../src",
+      {
+        "importSources": ["@apollo/client", "primary-gateway-graphql-tag"],
+        "gqlTagIdentifiers": ["gql", "gqlTagPrimaryGateway"],
+        "strip": true
+      }
+    ]
+  ]
+}

--- a/test/fixtures/graphql-tag/allows a custom tag identifier/output.mjs
+++ b/test/fixtures/graphql-tag/allows a custom tag identifier/output.mjs
@@ -1,0 +1,37 @@
+const foo = {
+  "kind": "Document",
+  "definitions": [{
+    "kind": "OperationDefinition",
+    "operation": "query",
+    "name": {
+      "kind": "Name",
+      "value": "foo"
+    },
+    "variableDefinitions": [],
+    "directives": [],
+    "selectionSet": {
+      "kind": "SelectionSet",
+      "selections": [{
+        "kind": "Field",
+        "name": {
+          "kind": "Name",
+          "value": "foo"
+        },
+        "arguments": [],
+        "directives": []
+      }]
+    }
+  }],
+  "loc": {
+    "start": 0,
+    "end": 14,
+    "source": {
+      "body": "query foo{foo}",
+      "name": "GraphQL request",
+      "locationOffset": {
+        "line": 1,
+        "column": 1
+      }
+    }
+  }
+};


### PR DESCRIPTION
Adds an option `gqlTagIdentifiers` which lets the plugin match on multiple different gql tag identifiers.