### PR TITLE
Fix build compatibility with NPM 7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-flow": "^7.0.0",
     "cross-env": "^7.0.2",
-    "eslint": "^5.13.0",
+    "eslint": "^7.0.0",
     "eslint-config-canonical": "^21.0.2",
     "flow-bin": "^0.93.0",
     "graphql": "^14.3.0",


### PR DESCRIPTION
NPM 7 will now validate peerDependencies [1].

`eslint-config-canonical@21.0.2` depends on `eslint@7` so this repository's dev dependency needs to be bumped.

The repository's travis build is failing due to the `node` build using
node 15 and NPM 7. This blocks #54.

1 - https://github.com/npm/rfcs/blob/latest/implemented/0025-install-peer-deps.md