### PR TITLE
chore: add PURE annotations for bundlers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import {stripIgnoredCharacters} from 'graphql';
 
 const debug = createDebug('babel-plugin-graphql-tag');
 const {
+  addComment,
   cloneDeep,
   isIdentifier,
   isMemberExpression,
@@ -23,6 +24,8 @@ const {
   identifier,
   isObjectPattern,
 } = types;
+
+const PURE_ANNOTATION = '#__PURE__';
 
 // eslint-disable-next-line no-restricted-syntax
 const uniqueFn = parseExpression(`
@@ -108,6 +111,12 @@ export default declare((api, options) => {
       );
 
       definitionsProperty.value = callExpression(uniqueId, [allDefinitions]);
+
+      // Marking these function calls with an annotation indicating that
+      // they're pure will allow bundlers like Webpack and Rollup to more
+      // aggressively remove unused queries from bundles.
+      addComment(allDefinitions, 'leading', PURE_ANNOTATION);
+      addComment(definitionsProperty.value, 'leading', PURE_ANNOTATION);
 
       uniqueUsed = true;
     }

--- a/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/output.mjs
+++ b/test/fixtures/apollov3/converts inline gql tag with fragment interpolation/output.mjs
@@ -122,7 +122,7 @@ const baz = {
 };
 const foo = {
   "kind": "Document",
-  "definitions": _unique([{
+  "definitions": /*#__PURE__*/_unique( /*#__PURE__*/[{
     "kind": "OperationDefinition",
     "operation": "query",
     "name": {

--- a/test/fixtures/graphql-tag/converts inline gql tag with fragment interpolation/output.mjs
+++ b/test/fixtures/graphql-tag/converts inline gql tag with fragment interpolation/output.mjs
@@ -122,7 +122,7 @@ const baz = {
 };
 const foo = {
   "kind": "Document",
-  "definitions": _unique([{
+  "definitions": /*#__PURE__*/_unique( /*#__PURE__*/[{
     "kind": "OperationDefinition",
     "operation": "query",
     "name": {


### PR DESCRIPTION
This PR adds `/*#__PURE__*/` annotations to function calls in the generated code. This allows bundlers like Webpack and Rollup to be more aggressive when removing unused code with dead code elimination and tree shaking. Without these annotations, unused queries will still end up in bundles, which will unnecessarily bloat them.

See [Webpack's tree shaking guide](https://webpack.js.org/guides/tree-shaking/) for more information and documentation about this annotation.