### PR TITLE
fix: add missing peer dependency `graphql`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.0",
     "graphql-tag": "^2.10.1",
-    "graphql": "^14.3.0"
+    "graphql": "^14.0.0 || ^15.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "name": "babel-plugin-graphql-tag",
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "graphql-tag": "^2.10.1"
+    "graphql-tag": "^2.10.1",
+    "graphql": "^14.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added `graphql` as a peer dependency since it's required at runtime but not declared as a dependency
https://github.com/gajus/babel-plugin-graphql-tag/blob/c49e30db46c46e84e75a044d0fd812ec40dc1772/src/index.js#L10